### PR TITLE
Fix typo in component.py error message

### DIFF
--- a/epoxy/component.py
+++ b/epoxy/component.py
@@ -134,7 +134,7 @@ class Component(object):
                 if dependency.required:
                     raise ValueError(
                         "'%s' is a required dependency of '%s' but was not "
-                        "specified when from_dependncies"
+                        "specified when from_dependencies"
                         " was called" % (key, cls.__name__))
                 dep_inst = dependency.bound_instance(dependency.default)
             else:


### PR DESCRIPTION
Just a small typo fix. Thanks!