### PR TITLE
python 3.5: add testing support for python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=pypy
   - TOX_ENV=coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 # this version of python is only used to run tox - the version specified by TOX_ENV
 # is used to install and run tests
-python: 2.7
+python: 3.5
 env:
   - TOX_ENV=py27
   - TOX_ENV=py32
@@ -20,3 +20,6 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - tox -e $TOX_ENV
+
+# Use new container based infrastructure
+sudo: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py32,py33,py34,pypy
+envlist = py27,py32,py33,py34,py35,pypy
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands=nosetests -m '^(int|unit)?[Tt]est'
 [testenv:coverage]
 deps=
   {[testenv]deps}
-  coverage
+  coverage==3.7.1
   python-coveralls
 commands =
   coverage run --branch --omit={envdir}/* {envbindir}/nosetests

--- a/toxtest.sh
+++ b/toxtest.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Script that will try to test this codebase against as many
+# python versions as is possible.  It does this using a combination
+# of pyenv (for building various interpreters) and tox for
+# testing using each of those interpreters.
+#
+
+pyversions=(2.7.10
+            3.3.5
+            3.4.3
+            3.5.0
+            pypy-2.6.0
+            pypy3-2.4.0)
+
+# parse options
+for i in "$@"
+do
+    case $i in
+        --fast)
+            FAST=YES
+            ;;
+    esac
+done
+
+if [ ! FAST="YES" ]; then
+    # first make sure that pyenv is installed
+    if [ ! -s "$HOME/.pyenv/bin/pyenv" ]; then
+        curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+    fi
+fi
+
+# Update pyenv (required for new python versions to be available)
+(cd $HOME/.pyenv && git pull)
+
+# add pyenv to our path and initialize (if this has not already been done)
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+
+# install each python version that we want to test with
+for pyversion in ${pyversions[*]};
+do
+    pyenv install -s ${pyversion}
+done
+pyenv rehash
+
+# This is required
+pyenv global ${pyversions[*]}
+
+# Now, run the tests after sourcing venv for tox install/use
+if [ ! FAST="YES" ]; then
+    virtualenv -q .toxenv
+fi
+source .toxenv/bin/activate
+if [ ! FAST="YES" ]; then
+    pip install -q -r dev-requirements.txt
+fi
+
+if FAST="YES"; then
+    tox
+else
+    # will ensure all depencies are pulled in
+    tox --recreate
+fi


### PR DESCRIPTION
There are two parts to this:
- travis/tox updates to test against python 3.5
- shell script to get python versions locally with pyenv

Signed-off-by: Paul Osborne <Paul.Osborne@digi.com>