### PR TITLE
Add functionality for EnvironmentSettings

### DIFF
--- a/epoxy/component.py
+++ b/epoxy/component.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2014 Etherios, Inc. All rights reserved.
 # Etherios, Inc. is a Division of Digi International.
 
-from epoxy.settings import BaseSetting, SettingInstance, ListSetting
+from epoxy.settings import BaseSetting, ListSetting
 import six
 
 
@@ -148,16 +148,15 @@ class Component(object):
                 if setting.required:
                     raise ValueError("'%s' is a required setting but was "
                                      "not specified" % key)
-                dep_inst = setting.bound_instance(setting.default)
             else:
                 match = settings_matches[key]
-                dep_inst = setting.bound_instance(setting.decode(match))
-            dependencies_settings_lookup[key] = dep_inst
+                setting.set_value(setting.decode(match))
+            dependencies_settings_lookup[key] = setting
 
         # now call __init__ to finish construction
         instance._dependencies_settings_lookup = dependencies_settings_lookup
         for attr, obj in six.iteritems(dependencies_settings_lookup):
-            if isinstance(obj, SettingInstance):
+            if isinstance(obj, BaseSetting):
                 obj = obj.get_value()
             setattr(instance, attr, obj)
         instance._launched = False

--- a/epoxy/settings.py
+++ b/epoxy/settings.py
@@ -6,36 +6,24 @@
 # Etherios, Inc. is a Division of Digi International.
 
 """Abstract and Concrete settings classes that may be used in applications"""
-
-
-class SettingInstance(object):
-    """Encapsulate a reference to some setting"""
-
-    def __init__(self, setting_type, initial_value):
-        self.type = setting_type
-        self._value = initial_value
-
-    def get_value(self):
-        return self._value
-
-    def set_value(self, obj, value):
-        self._value = value
+import os
 
 
 class BaseSetting(object):
     """Base class for all settings"""
-
-    instance_type = SettingInstance
 
     def __init__(self, required=False, default=None, help=""):  # @ReservedAssignment
         self.name = None
         self.required = required
         self.default = default
         self.help = help
+        self.value = default
 
-    @classmethod
-    def bound_instance(cls, value):
-        return cls.instance_type(cls, value)
+    def get_value(self):
+        return self.value
+
+    def set_value(self, value):
+        self.value = value
 
     def encode(self, value):
         """
@@ -117,3 +105,24 @@ class DictionarySetting(BaseSetting):
 
     def decode(self, value):
         return value
+
+
+class EnvironmentSetting(BaseSetting):
+
+    def __init__(self, required=False, default=None, help="", env_variable_name=""):
+        BaseSetting.__init__(self, required, default, help)
+        self.env_variable_name = env_variable_name
+
+    def get_value(self):
+        # Use actual environment variable if available, otherwise use the set value
+        env_value = os.getenv(self.env_variable_name, None)
+        if env_value is not None:
+            return env_value
+        else:
+            return self.value
+
+    def encode(self, value):
+        return str(value)
+
+    def decode(self, value):
+        return str(value)

--- a/epoxy/test/test_core.py
+++ b/epoxy/test/test_core.py
@@ -155,6 +155,18 @@ class TestDependencyGraphResolution(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.mgr.launch_subgraph(configuration, 'd:main')
 
+    def test_settings(self):
+        config = self.loader.load_configuration()
+        self.mgr.launch_configuration(config)
+        a = self.mgr.components["a"]
+        b = self.mgr.components["b"]
+        c = self.mgr.components["c"]
+        d = self.mgr.components["d"]
+        self.assertEqual(a.name, 'alfred')
+        self.assertEqual(b.name, 'barry')
+        self.assertEqual(c.name, 'charles')
+        self.assertEqual(d.name, 'daniel')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
EnvironmentSettings allow for epoxy components to take their value from
operating system environment variables.  The order of preference for the
settings variables is OS environment variable value, yaml configuration
value, default value.

The SettingInstance object was not necessary for the way it was being used.  Since it was only used in an intermediary way within the from_dependencies method, it was removed and the functionality folded into the Settings themselves.  This allows for the proper control of the precedence of values for EnvironmentSettings
